### PR TITLE
Persist access token

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,11 @@ npm start
 ```
 
 The script outputs each mower name, model and current activity.
+
+### Access Token Persistence
+
+After a successful authentication, the script stores the received access token in
+`$HOME/.config/autoplanner/access_token.json`. The file includes the token and
+its expiration timestamp so that subsequent runs can reuse the token until it
+expires. The file is created with owner-only permissions to keep the token
+private.


### PR DESCRIPTION
## Summary
- persist auth token under `$HOME/.config/autoplanner`
- detail token persistence in README
- secure token storage with restrictive permissions

## Testing
- `node index.js` *(fails: HQ_API_KEY and HQ_API_SECRET must be provided)*

------
https://chatgpt.com/codex/tasks/task_e_6884ccfba96c83248e601a839e9e804c