### PR TITLE
Ensure DB directory exists before opening

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -1,9 +1,12 @@
 import Database from 'better-sqlite3';
+import fs from 'node:fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const dbPath = path.join(__dirname, '../db/mower-data.sqlite');
+const dbDir = path.join(__dirname, '../db');
+await fs.mkdir(dbDir, { recursive: true });
+const dbPath = path.join(dbDir, 'mower-data.sqlite');
 
 const db = new Database(dbPath);
 


### PR DESCRIPTION
## Summary
- create `../db` directory if missing before opening SQLite database

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6885e93eed488324900bc1c2caca5a5e