### PR TITLE
Update README for web server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Automower API Example
 
-This repository contains a simple Node.js script to fetch your Husqvarna Automower information using the Automower Connect API. The script authenticates using the Authentication API and prints basic mower details.
+This repository contains a small Node.js application that connects to the Husqvarna Automower Connect API and stores mower position data in a local SQLite database. It runs a web server that exposes an API endpoint and a simple heatmap page to visualise your mower's activity.
 
 ## Requirements
 
@@ -16,13 +16,13 @@ This repository contains a simple Node.js script to fetch your Husqvarna Automow
 
 ## Usage
 
-Run the script with:
+Run the server with:
 
 ```bash
 npm start
 ```
 
-The script outputs each mower name, model and current activity.
+This launches `src/app.js`, which starts an HTTP server on `http://localhost:3000`. View `public/map.html` (for example at `http://localhost:3000/map.html`) to see a heatmap of recorded mower positions.
 
 ### Access Token Persistence
 

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "automower",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "src/app.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node index.js"
+    "start": "node src/app.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- describe new HTTP server and heat map in README
- document how to start the server
- update package.json start script

## Testing
- `npm test` *(fails: no test specified)*
- `npm start` *(fails: cannot find module 'express' due to missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_6885e964dc708324a5401b47fd74d811