### PR TITLE
Add overlay for recent mower positions

### DIFF
--- a/public/map.html
+++ b/public/map.html
@@ -21,6 +21,7 @@
     }).addTo(map);
 
     let heatLayer = null;
+    let recentLayer = null;
 
     function loadHeatmap() {
         fetch('/api/positions')
@@ -44,8 +45,30 @@
             });
     }
 
+    function loadRecent() {
+        fetch('/api/recent-positions')
+            .then(res => res.json())
+            .then(points => {
+                if (recentLayer) {
+                    map.removeLayer(recentLayer);
+                }
+                recentLayer = L.layerGroup();
+                points.forEach(([lat, lon]) => {
+                    L.circleMarker([lat, lon], {
+                        radius: 3,
+                        color: 'white',
+                        weight: 1,
+                        fillColor: 'white',
+                        fillOpacity: 1
+                    }).addTo(recentLayer);
+                });
+                recentLayer.addTo(map);
+            });
+    }
+
     loadHeatmap();
-    setInterval(loadHeatmap, 60000);
+    loadRecent();
+    setInterval(() => { loadHeatmap(); loadRecent(); }, 60000);
   </script>
 </body>
 </html>

--- a/src/db.js
+++ b/src/db.js
@@ -32,6 +32,13 @@ const selectStmt = db.prepare(`
   `
 );
 
+const recentStmt = db.prepare(
+  `SELECT mower_id, lat, lon, timestamp, activity
+   FROM positions
+   ORDER BY timestamp DESC
+   LIMIT ?`
+);
+
 function storePosition(mowerId, state, lat, lon, timestamp) {
   insertStmt.run(mowerId, state, lat, lon, timestamp);
 }
@@ -40,4 +47,8 @@ function getPositions() {
   return selectStmt.all();
 }
 
-export { storePosition,  getPositions };
+function getRecentPositions(limit = 50) {
+  return recentStmt.all(limit);
+}
+
+export { storePosition, getPositions, getRecentPositions };

--- a/src/server.js
+++ b/src/server.js
@@ -2,6 +2,7 @@ import express from 'express';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { getInterpolatedPositions } from './interpolate.js';
+import { getRecentPositions } from './db.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const app = express();
@@ -12,6 +13,12 @@ app.get('/api/positions', (req, res) => {
   const data = getInterpolatedPositions();
   const heat = data.map(([lat, lon, weight]) => [lat, lon, weight]);
   res.json(heat);
+});
+
+app.get('/api/recent-positions', (req, res) => {
+  const rows = getRecentPositions(50);
+  const coords = rows.map(r => [r.lat, r.lon]);
+  res.json(coords);
 });
 
 export function startHttpServer(port = 3000) {


### PR DESCRIPTION
## Summary
- expose recent positions in DB
- serve recent positions via `/api/recent-positions`
- overlay last 50 raw points as white circle markers on the map

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6888d3fde9708324a538d685249229b1