### PR TITLE
[codex] Fix mower local message timestamps

### DIFF
--- a/src/amconnect.js
+++ b/src/amconnect.js
@@ -23,7 +23,10 @@ export function handleIncomingEvent(data) {
       console.log("🔒 Connected")
     }
 
-    const shapedEvent = shapeEventForStorage(message);
+    const { type, attributes, id: mowerId } = message;
+    const currentState = mowerId ? getMowerState(mowerId) : null;
+    const mowerTimeZone = currentState?.timeZone ?? attributes?.settings?.timeZone ?? null;
+    const shapedEvent = shapeEventForStorage(message, { mowerTimeZone });
     let eventId = null;
     let eventTimestampIso = null;
     if (shapedEvent) {
@@ -35,12 +38,11 @@ export function handleIncomingEvent(data) {
       }
     }
 
-    const { type, attributes, id: mowerId } = message;
     if (!type || !attributes || !mowerId) return;
 
     const mowerIdShort = mowerId.substring(0, 8);
-    const currentState = getMowerState(mowerId);
     const mowerName = currentState?.mowerName || 'Unknown';
+    const timeZone = mowerTimeZone ?? currentState?.timeZone ?? null;
     const lastEventTimestamp = eventTimestampIso ?? shapedEvent?.receivedAt ?? new Date().toISOString();
 
     if (type === 'mower-event-v2') {
@@ -52,6 +54,7 @@ export function handleIncomingEvent(data) {
           console.log(`📍 Activity changed for ${mowerName} (${mowerIdShort}): ${activity} at ${activityTimestampIso}`);
           updateMowerState(mowerId, {
             mowerName,
+            timeZone,
             activity,
             sessionId: Number.isNaN(activityTimestampMs) ? Date.now() : activityTimestampMs,
             lastActivityAt: activityTimestampIso,
@@ -62,6 +65,7 @@ export function handleIncomingEvent(data) {
       } else {
         updateMowerState(mowerId, {
           mowerName,
+          timeZone,
           lastEventAt: lastEventTimestamp
         });
       }
@@ -87,6 +91,7 @@ export function handleIncomingEvent(data) {
 
         updateMowerState(mowerId, {
           mowerName,
+          timeZone,
           lastPosition: { lat, lon, timestamp, eventId },
           lastEventAt: lastEventTimestamp
         });
@@ -95,7 +100,7 @@ export function handleIncomingEvent(data) {
     } else if (type === 'message-event-v2') {
       const lat = attributes?.message?.latitude;
       const lon = attributes?.message?.longitude;
-      const timestampIso = toIsoTimestamp(attributes?.message?.time) ?? new Date().toISOString();
+      const timestampIso = eventTimestampIso ?? new Date().toISOString();
       const code = attributes?.message?.code ?? null;
       const severity = attributes?.message?.severity ?? null;
 
@@ -106,6 +111,7 @@ export function handleIncomingEvent(data) {
 
       updateMowerState(mowerId, {
         mowerName,
+        timeZone,
         lastEventAt: lastEventTimestamp ?? timestampIso,
         lastMessage: code != null || severity != null ? {
           code,
@@ -122,6 +128,7 @@ export function handleIncomingEvent(data) {
       const pct = pctRaw == null ? null : Math.round(Number(pctRaw));
       updateMowerState(mowerId, {
         mowerName,
+        timeZone,
         batteryPercent: Number.isFinite(pct) ? Math.max(0, Math.min(100, pct)) : null,
         lastBatteryAt: lastEventTimestamp,
         lastEventAt: lastEventTimestamp
@@ -129,6 +136,7 @@ export function handleIncomingEvent(data) {
     } else {
       updateMowerState(mowerId, {
         mowerName,
+        timeZone,
         lastEventAt: lastEventTimestamp
       });
     }

--- a/src/app.js
+++ b/src/app.js
@@ -35,11 +35,13 @@ async function loadMowerState(token, apiKey, apiSecret) {
     for (const mower of initialData.data ?? []) {
       const mowerId = mower.id;
       const mowerName = mower.attributes?.system?.name || 'Unknown';
+      const timeZone = mower.attributes?.settings?.timeZone ?? null;
       const activity = mower.attributes?.mower?.activity ?? 'UNKNOWN';
       const batteryRaw = mower.attributes?.battery?.batteryPercent;
       const batteryPercent = batteryRaw == null ? null : Math.round(Number(batteryRaw));
       const state = updateMowerState(mowerId, {
         mowerName,
+        timeZone,
         activity,
         sessionId: nowTs,
         lastActivityAt: nowIso,

--- a/src/events.js
+++ b/src/events.js
@@ -24,6 +24,61 @@ export function toIsoTimestamp(value) {
   return null;
 }
 
+function getTimeZoneOffsetMs(timeZone, instantMs) {
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hourCycle: 'h23'
+  });
+  const parts = Object.fromEntries(
+    formatter.formatToParts(new Date(instantMs))
+      .filter((part) => part.type !== 'literal')
+      .map((part) => [part.type, Number(part.value)])
+  );
+
+  return Date.UTC(
+    parts.year,
+    parts.month - 1,
+    parts.day,
+    parts.hour,
+    parts.minute,
+    parts.second
+  ) - instantMs;
+}
+
+export function toIsoTimestampFromLocalTime(value, timeZone) {
+  if (!timeZone) return toIsoTimestamp(value);
+
+  const utcIso = toIsoTimestamp(value);
+  if (!utcIso) return null;
+
+  try {
+    const utcDate = new Date(utcIso);
+    let instantMs = Date.UTC(
+      utcDate.getUTCFullYear(),
+      utcDate.getUTCMonth(),
+      utcDate.getUTCDate(),
+      utcDate.getUTCHours(),
+      utcDate.getUTCMinutes(),
+      utcDate.getUTCSeconds(),
+      utcDate.getUTCMilliseconds()
+    );
+
+    for (let i = 0; i < 3; i += 1) {
+      instantMs = Date.parse(utcIso) - getTimeZoneOffsetMs(timeZone, instantMs);
+    }
+
+    return new Date(instantMs).toISOString();
+  } catch {
+    return utcIso;
+  }
+}
+
 function extractCoordinates(eventType, attributes) {
   if (!attributes) return { lat: null, lon: null };
 
@@ -50,20 +105,20 @@ function extractMessageDetails(attributes) {
   };
 }
 
-function deriveTimestamp(message) {
+function deriveTimestamp(message, { mowerTimeZone } = {}) {
   const attributes = message?.attributes ?? {};
 
   return (
     toIsoTimestamp(attributes?.metadata?.timestamp) ??
-    toIsoTimestamp(attributes?.message?.time) ??
-    toIsoTimestamp(attributes?.mower?.errorCodeTimestamp) ??
-    toIsoTimestamp(attributes?.planner?.nextStartTimestamp) ??
+    toIsoTimestampFromLocalTime(attributes?.message?.time, mowerTimeZone) ??
+    toIsoTimestampFromLocalTime(attributes?.mower?.errorCodeTimestamp, mowerTimeZone) ??
+    toIsoTimestampFromLocalTime(attributes?.planner?.nextStartTimestamp, mowerTimeZone) ??
     toIsoTimestamp(attributes?.position?.timestamp) ??
     null
   );
 }
 
-export function shapeEventForStorage(message) {
+export function shapeEventForStorage(message, options = {}) {
   if (!message || typeof message !== 'object') return null;
 
   const receivedAt = new Date().toISOString();
@@ -85,7 +140,7 @@ export function shapeEventForStorage(message) {
   const { id: mowerId, type, attributes } = message;
   if (!type || !mowerId) return null;
 
-  const eventTimestamp = deriveTimestamp(message) ?? receivedAt;
+  const eventTimestamp = deriveTimestamp(message, options) ?? receivedAt;
   const { lat, lon } = extractCoordinates(type, attributes);
   const { code: messageCode, severity: messageSeverity } = extractMessageDetails(attributes);
 

--- a/src/events.test.js
+++ b/src/events.test.js
@@ -1,0 +1,20 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { shapeEventForStorage } from './events.js';
+
+test('message local timestamp is normalized with mower timezone', () => {
+  const shaped = shapeEventForStorage({
+    id: 'mower-1',
+    type: 'message-event-v2',
+    attributes: {
+      message: {
+        time: 1778405143,
+        code: 78,
+        severity: 'ERROR'
+      }
+    }
+  }, { mowerTimeZone: 'Europe/Stockholm' });
+
+  assert.equal(shaped.eventTimestamp, '2026-05-10T07:25:43.000Z');
+});

--- a/src/state.js
+++ b/src/state.js
@@ -2,6 +2,7 @@ export const mowerStates = new Map();
 
 const defaultState = {
   mowerName: 'Unknown',
+  timeZone: null,
   activity: 'UNKNOWN',
   sessionId: null,
   lastActivityAt: null,


### PR DESCRIPTION
## Summary

Normalize mower-local message timestamps with the mower timezone from `attributes.settings.timeZone` before storing/displaying them.

## Root Cause

`message.time` and similar mower-local timestamp fields were treated as normal UTC Unix timestamps. For a mower in `Europe/Stockholm`, this caused values such as `1778405143` to be stored as `2026-05-10T09:25:43.000Z` instead of the real instant `2026-05-10T07:25:43.000Z`, so the browser applied the local offset again and displayed a time two hours late during CEST.

## Changes

- Store the mower timezone from the startup `/v1/mowers` payload.
- Pass that timezone into event shaping for incoming WebSocket events.
- Add timezone-aware normalization for mower-local timestamp fields.
- Reuse the shaped timestamp for live message state so DB-backed and live UI paths agree.
- Add a regression test for the reported `Europe/Stockholm` timestamp case.

## Validation

- `npm test`